### PR TITLE
When papermill fails, the step should fail.

### DIFF
--- a/.github/workflows/execute_notebooks.yml
+++ b/.github/workflows/execute_notebooks.yml
@@ -33,4 +33,4 @@ jobs:
         # The notebook output will be directed to /dev/null but if there is any
         # error execution will stop and the error will be shown in stderr (and
         # hence in the logs).
-        jupyter-repo2docker . /bin/bash -c "pip install papermill && find . -not -path '*/\.*' -name '*.ipynb' -exec papermill {} - > /dev/null \;"
+        jupyter-repo2docker . /bin/bash -c "pip install papermill && find . -not -path '*/\.*' -name '*.ipynb' -print0 | xargs -0 -I _ papermill _ - > /dev/null"


### PR DESCRIPTION
A nonzero exitcode from papermill was being masked by
`find ... -exec ...` which normally returns 0 as long as the
file-walking itself succeeds, regardless of whether the target of
-exec does.

https://apple.stackexchange.com/q/49042

Switching from -exec to xargs did the trick.

This is expected to make the CI fail, but that is a correct reflection of the reality that the notebook's requirements are not yet fully specified. The fix for that actual issue will come in a separate PR from @tankonst.